### PR TITLE
Use `WalkDir` when listing SQL files to be able to support a schema that is organized in various directories.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +567,7 @@ dependencies = [
  "chrono",
  "clap",
  "postgres",
+ "pretty_assertions",
  "regex",
  "serial_test",
  "walkdir",
@@ -571,6 +578,16 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -1004,3 +1021,9 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,7 @@ dependencies = [
  "postgres",
  "regex",
  "serial_test",
+ "walkdir",
 ]
 
 [[package]]
@@ -674,6 +675,15 @@ name = "rustversion"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -904,6 +914,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "3", features = ["derive", "env"] }
 walkdir = "2.5"
 
 [dev-dependencies]
+pretty_assertions = "1.4"
 serial_test = "0.8"
 # https://docs.rs/assert_cmd/latest/assert_cmd/
 # assert_cmd = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ chrono = "0.4"
 regex = "1"
 anyhow = "1.0"
 clap = { version = "3", features = ["derive", "env"] }
+walkdir = "2.5"
 
 [dev-dependencies]
 serial_test = "0.8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,37 +107,37 @@ fn test_list_sql_files_nested_schema() -> io::Result<()> {
 	ensure_directory(&DEFAULT_SCHEMA_DIRECTORY)?;
 
 	fs::File::create("schema/README")?;
-	fs::File::create("schema/00_types.sql")?;
+	fs::File::create("schema/00_base.sql")?;
 	fs::create_dir("schema/01_tables")?;
-	fs::File::create("schema/01_tables/00_foo.sql")?;
-	fs::create_dir("schema/01_tables/01_bar_tables")?;
-	fs::File::create("schema/01_tables/01_bar_tables/README")?;
-	fs::File::create("schema/01_tables/01_bar_tables/bar_0.sql")?;
-	fs::File::create("schema/01_tables/01_bar_tables/bar_1.sql")?;
+	fs::File::create("schema/01_tables/00_tables.sql")?;
+	fs::create_dir("schema/01_tables/01_tables")?;
+	fs::File::create("schema/01_tables/01_tables/README")?;
+	fs::File::create("schema/01_tables/01_tables/00_tables.sql")?;
+	fs::File::create("schema/01_tables/01_tables/01_tables.sql")?;
 	fs::create_dir("schema/02_functions")?;
-	fs::File::create("schema/02_functions/00_common.sql")?;
-	fs::create_dir("schema/02_functions/01_bar_functions")?;
-	fs::File::create("schema/02_functions/01_bar_functions/00_get_bar.sql")?;
-	fs::File::create("schema/02_functions/01_bar_functions/01_aggregate_bar.sql")?;
-	fs::create_dir("schema/02_functions/02_foo_functions")?;
-	fs::File::create("schema/02_functions/02_foo_functions/README")?;
-	fs::File::create("schema/02_functions/02_foo_functions/00_get_foo.sql")?;
-	fs::File::create("schema/02_functions/02_foo_functions/01_aggregate_foo.sql")?;
+	fs::File::create("schema/02_functions/00_functions.sql")?;
+	fs::create_dir("schema/02_functions/01_functions")?;
+	fs::File::create("schema/02_functions/01_functions/00_functions.sql")?;
+	fs::File::create("schema/02_functions/01_functions/01_functions.sql")?;
+	fs::create_dir("schema/02_functions/02_functions")?;
+	fs::File::create("schema/02_functions/02_functions/README")?;
+	fs::File::create("schema/02_functions/02_functions/00_functions.sql")?;
+	fs::File::create("schema/02_functions/02_functions/01_functions.sql")?;
 	fs::File::create("schema/03_indexes.sql")?;
 
 	let schema_files = list_sql_files(&DEFAULT_SCHEMA_DIRECTORY)?;
 	assert_eq!(
 		schema_files,
 		vec![
-			PathBuf::from("schema/00_types.sql"),
-			PathBuf::from("schema/01_tables/00_foo.sql"),
-			PathBuf::from("schema/01_tables/01_bar_tables/bar_0.sql"),
-			PathBuf::from("schema/01_tables/01_bar_tables/bar_1.sql"),
-			PathBuf::from("schema/02_functions/00_common.sql"),
-			PathBuf::from("schema/02_functions/01_bar_functions/00_get_bar.sql"),
-			PathBuf::from("schema/02_functions/01_bar_functions/01_aggregate_bar.sql"),
-			PathBuf::from("schema/02_functions/02_foo_functions/00_get_foo.sql"),
-			PathBuf::from("schema/02_functions/02_foo_functions/01_aggregate_foo.sql"),
+			PathBuf::from("schema/00_base.sql"),
+			PathBuf::from("schema/01_tables/00_tables.sql"),
+			PathBuf::from("schema/01_tables/01_tables/00_tables.sql"),
+			PathBuf::from("schema/01_tables/01_tables/01_tables.sql"),
+			PathBuf::from("schema/02_functions/00_functions.sql"),
+			PathBuf::from("schema/02_functions/01_functions/00_functions.sql"),
+			PathBuf::from("schema/02_functions/01_functions/01_functions.sql"),
+			PathBuf::from("schema/02_functions/02_functions/00_functions.sql"),
+			PathBuf::from("schema/02_functions/02_functions/01_functions.sql"),
 			PathBuf::from("schema/03_indexes.sql"),
 		]
 	);

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,17 +60,17 @@ fn test_make_slug() {
 
 
 fn list_sql_files(directory: &str) -> io::Result<Vec<PathBuf>> {
-    let mut entries = vec![];
-    let sql_extension = Some(std::ffi::OsStr::new("sql"));
+	let mut entries = vec![];
+	let sql_extension = Some(std::ffi::OsStr::new("sql"));
 
-    for entry in WalkDir::new(directory) {
-        let path = entry?.into_path();
-        if !path.is_dir() && path.extension() == sql_extension {
-            entries.push(path);
-        }
-    }
-    entries.sort();
-    Ok(entries)
+	for entry in WalkDir::new(directory) {
+		let path = entry?.into_path();
+		if !path.is_dir() && path.extension() == sql_extension {
+			entries.push(path);
+		}
+	}
+	entries.sort();
+	Ok(entries)
 }
 
 #[test]
@@ -101,49 +101,49 @@ fn test_list_sql_files() -> io::Result<()> {
 #[test]
 #[serial_test::serial]
 fn test_list_sql_files_nested_schema() -> io::Result<()> {
-    use pretty_assertions::assert_eq;
+	use pretty_assertions::assert_eq;
 
-    purge_directory(&DEFAULT_SCHEMA_DIRECTORY)?;
-    ensure_directory(&DEFAULT_SCHEMA_DIRECTORY)?;
+	purge_directory(&DEFAULT_SCHEMA_DIRECTORY)?;
+	ensure_directory(&DEFAULT_SCHEMA_DIRECTORY)?;
 
-    fs::File::create("schema/README")?;
-    fs::File::create("schema/00_types.sql")?;
-    fs::create_dir("schema/01_tables")?;
-    fs::File::create("schema/01_tables/00_foo.sql")?;
-    fs::create_dir("schema/01_tables/01_bar_tables")?;
-    fs::File::create("schema/01_tables/01_bar_tables/README")?;
-    fs::File::create("schema/01_tables/01_bar_tables/bar_0.sql")?;
-    fs::File::create("schema/01_tables/01_bar_tables/bar_1.sql")?;
-    fs::create_dir("schema/02_functions")?;
-    fs::File::create("schema/02_functions/00_common.sql")?;
-    fs::create_dir("schema/02_functions/01_bar_functions")?;
-    fs::File::create("schema/02_functions/01_bar_functions/00_get_bar.sql")?;
-    fs::File::create("schema/02_functions/01_bar_functions/01_aggregate_bar.sql")?;
-    fs::create_dir("schema/02_functions/02_foo_functions")?;
-    fs::File::create("schema/02_functions/02_foo_functions/README")?;
-    fs::File::create("schema/02_functions/02_foo_functions/00_get_foo.sql")?;
-    fs::File::create("schema/02_functions/02_foo_functions/01_aggregate_foo.sql")?;
-    fs::File::create("schema/03_indexes.sql")?;
+	fs::File::create("schema/README")?;
+	fs::File::create("schema/00_types.sql")?;
+	fs::create_dir("schema/01_tables")?;
+	fs::File::create("schema/01_tables/00_foo.sql")?;
+	fs::create_dir("schema/01_tables/01_bar_tables")?;
+	fs::File::create("schema/01_tables/01_bar_tables/README")?;
+	fs::File::create("schema/01_tables/01_bar_tables/bar_0.sql")?;
+	fs::File::create("schema/01_tables/01_bar_tables/bar_1.sql")?;
+	fs::create_dir("schema/02_functions")?;
+	fs::File::create("schema/02_functions/00_common.sql")?;
+	fs::create_dir("schema/02_functions/01_bar_functions")?;
+	fs::File::create("schema/02_functions/01_bar_functions/00_get_bar.sql")?;
+	fs::File::create("schema/02_functions/01_bar_functions/01_aggregate_bar.sql")?;
+	fs::create_dir("schema/02_functions/02_foo_functions")?;
+	fs::File::create("schema/02_functions/02_foo_functions/README")?;
+	fs::File::create("schema/02_functions/02_foo_functions/00_get_foo.sql")?;
+	fs::File::create("schema/02_functions/02_foo_functions/01_aggregate_foo.sql")?;
+	fs::File::create("schema/03_indexes.sql")?;
 
-    let schema_files = list_sql_files(&DEFAULT_SCHEMA_DIRECTORY)?;
-    assert_eq!(
-        schema_files,
-        vec![
-            PathBuf::from("schema/00_types.sql"),
-            PathBuf::from("schema/01_tables/00_foo.sql"),
-            PathBuf::from("schema/01_tables/01_bar_tables/bar_0.sql"),
-            PathBuf::from("schema/01_tables/01_bar_tables/bar_1.sql"),
-            PathBuf::from("schema/02_functions/00_common.sql"),
-            PathBuf::from("schema/02_functions/01_bar_functions/00_get_bar.sql"),
-            PathBuf::from("schema/02_functions/01_bar_functions/01_aggregate_bar.sql"),
-            PathBuf::from("schema/02_functions/02_foo_functions/00_get_foo.sql"),
-            PathBuf::from("schema/02_functions/02_foo_functions/01_aggregate_foo.sql"),
-            PathBuf::from("schema/03_indexes.sql"),
-        ]
-    );
+	let schema_files = list_sql_files(&DEFAULT_SCHEMA_DIRECTORY)?;
+	assert_eq!(
+		schema_files,
+		vec![
+			PathBuf::from("schema/00_types.sql"),
+			PathBuf::from("schema/01_tables/00_foo.sql"),
+			PathBuf::from("schema/01_tables/01_bar_tables/bar_0.sql"),
+			PathBuf::from("schema/01_tables/01_bar_tables/bar_1.sql"),
+			PathBuf::from("schema/02_functions/00_common.sql"),
+			PathBuf::from("schema/02_functions/01_bar_functions/00_get_bar.sql"),
+			PathBuf::from("schema/02_functions/01_bar_functions/01_aggregate_bar.sql"),
+			PathBuf::from("schema/02_functions/02_foo_functions/00_get_foo.sql"),
+			PathBuf::from("schema/02_functions/02_foo_functions/01_aggregate_foo.sql"),
+			PathBuf::from("schema/03_indexes.sql"),
+		]
+	);
 
-    purge_directory(&DEFAULT_SCHEMA_DIRECTORY)?;
-    Ok(())
+	purge_directory(&DEFAULT_SCHEMA_DIRECTORY)?;
+	Ok(())
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,14 +16,14 @@ fn get_null_string() -> String {
 	"null".to_string()
 }
 
-fn ensure_directory(migrations_directory: &str) -> io::Result<()> {
-	fs::create_dir_all(migrations_directory)
+fn ensure_directory(directory: &str) -> io::Result<()> {
+	fs::create_dir_all(directory)
 }
 
-fn purge_directory(migrations_directory: &str) -> io::Result<()> {
-	let migrations_directory = PathBuf::from(migrations_directory);
-	match migrations_directory.exists() {
-		true => fs::remove_dir_all(migrations_directory),
+fn purge_directory(directory: &str) -> io::Result<()> {
+	let directory = PathBuf::from(directory);
+	match directory.exists() {
+		true => fs::remove_dir_all(directory),
 		false => Ok(()),
 	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,18 +60,17 @@ fn test_make_slug() {
 
 
 fn list_sql_files(directory: &str) -> io::Result<Vec<PathBuf>> {
-	let mut entries = vec![];
-	let sql_extension = Some(std::ffi::OsStr::new("sql"));
+    let mut entries = vec![];
+    let sql_extension = Some(std::ffi::OsStr::new("sql"));
 
-	for entry in fs::read_dir(directory)? {
-		let entry = entry?;
-		let path = entry.path();
-		if !path.is_dir() && path.extension() == sql_extension {
-			entries.push(path);
-		}
-	}
-	entries.sort();
-	Ok(entries)
+    for entry in WalkDir::new(directory) {
+        let path = entry?.into_path();
+        if !path.is_dir() && path.extension() == sql_extension {
+            entries.push(path);
+        }
+    }
+    entries.sort();
+    Ok(entries)
 }
 
 #[test]
@@ -616,6 +615,7 @@ impl Drop for TempDb {
 }
 
 use clap::Parser;
+use walkdir::WalkDir;
 
 #[derive(Parser, Debug)]
 #[clap(author, version)]


### PR DESCRIPTION
Thank you for this tool! I've used `migra` quite a bit in the past and it's nice to have a wrapper around it to handle everything with dealing with the database to make it much easier to simply generate migrations.

We have a fairly complex schema that we like to organize in a directory structure. The current implementation only reads files from the top-level `schema` directory, which won't suffice for our use case. This PR here adds that support by using `walk_dir` to get all of the files that are nested down in directories. There is a test added to verify that it lists these files in the correct order.

I also changed `purge_migrations_directory` and `ensure_migrations_directory` to `purge_directory` and `ensure_directory` since this used for the `schema` directory in the test and it's a general enough function to be used with any directory.

Let me know if you have any questions or would like anything adjusted!