### PR TITLE
Ensure the release.Dockerfile can build given the presumption of TLS.

### DIFF
--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -1,6 +1,7 @@
-FROM rust:latest AS builder
+FROM rust:alpine AS builder
 WORKDIR /usr/src/
-RUN rustup target add x86_64-unknown-linux-musl
+
+RUN apk add --no-cache musl-dev openssl-dev pkgconfig openssl-libs-static
 
 RUN USER=root cargo new postgres_migrator
 WORKDIR /usr/src/postgres_migrator
@@ -8,7 +9,7 @@ COPY Cargo.toml Cargo.lock ./
 RUN cargo build --release
 
 COPY src ./src
-RUN cargo install --target x86_64-unknown-linux-musl --path .
+RUN cargo install --path .
 
 
 FROM python:alpine


### PR DESCRIPTION
## Motivation

When trying to create an integration test for recently added TLS functionality, I noticed `just build` did in fact, not just build.

## Approach
Since adding the `native_tls` package, there is now a presumption something like `openSSL` is available natively. The `rust:latest` image does not, and requires quite a few changes to make work.

`rust:latest` uses `glibc` and and `rust:alpine` uses `musl libc`. Sticking to musl allows us to avoid cross-compilation challenges.

Without any insight into the previous builder image choices, I've opted to begin with the alpine image to reduce the number of docker build steps.